### PR TITLE
Support Model.upsert()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # sequelize-cockroach
-Use Sequelize and CockroachDB together
+
+This package makes Sequelize compatible with CockroachDB.
+
+(pointer to docs will go here)

--- a/index.js
+++ b/index.js
@@ -1,0 +1,71 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+'use strict';
+
+var Sequelize = require('sequelize');
+var QueryGenerator = require('sequelize/lib/dialects/postgres/query-generator.js');
+var QueryTypes = require('sequelize/lib/query-types.js');
+
+var upsertIssueURL = "https://github.com/cockroachdb/cockroach/issues/6637";
+
+// upsertQuery generates an upsert query using INSERT with an ON CONFLICT
+// clause. This overrides the Sequelize implementation for Postgres, which uses
+// a temporary stored procedure to handle upserts.
+//
+// Unlike the implementations of this method by other dialects, this method has
+// no return value.
+QueryGenerator.upsertQuery = function(tableName, insertValues, updateValues, where, rawAttributes, options) {
+  var self = this;
+  if (options.returning) {
+    throw new Error("RETURNING not supported with INSERT .. ON CONFLICT. See " + upsertIssueURL);
+  }
+
+  // Though this is an upsert, we want Sequelize to treat this as an INSERT.
+  // Sequelize treats upserts in Postgres as a call to a temporary stored
+  // procedure, which has a different return type than an INSERT.
+  options.type = QueryTypes.INSERT;
+  delete options.returning;
+
+  // Create base INSERT query.
+  var insert = this.insertQuery(tableName, insertValues, rawAttributes, options);
+  if (insert.slice(-1) !== ";") {
+    throw new Error("expected but did not find terminating semicolon in INSERT query");
+  }
+  insert = insert.slice(0, -1);
+
+  // Create the ON CONFLICT clause, using the primary key as the target.
+  var pkCols = [];
+  Object.keys(rawAttributes).forEach(function(key) {
+    if (rawAttributes[key].primaryKey) {
+      pkCols.push(self.quoteIdentifier(rawAttributes[key].field));
+    }
+  });
+  var onConflictSet = Object.keys(updateValues).map(function (key) {
+    key = this.quoteIdentifier(key);
+    return key + ' = excluded.'+key;
+  }, this).join(', ');
+
+  console.log(insert + " ON CONFlICT (" + pkCols.join(',') + ") DO UPDATE SET " + onConflictSet + ";");
+  return insert + " ON CONFlICT (" + pkCols.join(',') + ") DO UPDATE SET " + onConflictSet + ";";
+}
+
+Sequelize.supportsCockroachDB = true;
+
+/**
+  * The entry point.
+  *
+  * @module Sequelize
+  */
+module.exports = Sequelize;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "sequelize-cockroachdb",
+  "version": "1.0.0",
+  "description": "Support using Sequelize with CockroachDB.",
+  "main": "index.js",
+  "scripts": {
+    "test": "mocha --check-leaks --colors -t 60000 --reporter spec \"tests/*_test.js\""
+  },
+  "keywords": [
+    "database",
+    "sequelize",
+    "cockroach",
+    "cockroachdb",
+    "orm",
+    "object relational mapper"
+  ],
+  "author": "Cuong Do <cdo@cockroachlabs.com>",
+  "license": "Apache-2.0",
+  "devDependencies": {
+    "chai": "^3.5.0",
+    "chai-datetime": "^1.4.1",
+    "mocha": "^3.2.0"
+  },
+  "dependencies": {
+    "pg": "^6.1.3",
+    "sequelize": "^3.30.2"
+  },
+  "peerDependencies": {
+    "sequelize": "^3.30.2"
+  }
+}

--- a/tests/upsert_test.js
+++ b/tests/upsert_test.js
@@ -1,0 +1,170 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+// These tests run against a local instance of CockroachDB that meets the
+// following requirements:
+//
+// 1. Running with the --insecure flag.
+// 2. Contains a database named "sequelize_test".
+
+// To override the CockroachDB port, set the COCKROACH_PORT environment
+// variable.
+
+var chai = require('chai');
+var expect = chai.expect;
+var Sequelize = require('..');
+
+chai.use(require('chai-datetime'));
+
+function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+describe ('upsert', function () {
+  var cockroach_port = process.env.COCKROACH_PORT;
+  if (cockroach_port === undefined) {
+    cockroach_port = 26257;
+  }
+
+  before(function() {
+    this.sequelize = new Sequelize('sequelize_test', 'root', '', {
+      dialect: "postgres",
+      port: cockroach_port,
+      logging: false
+    });
+  });
+
+  it('supports CockroachDB', function () {
+    expect(Sequelize.supportsCockroachDB).to.be.true;
+  });
+
+  it('updates at most one row', function () {
+    var User = this.sequelize.define('user', {
+      id: {
+        type: Sequelize.INTEGER,
+        primaryKey: true
+      },
+      name: {
+        type: Sequelize.STRING,
+      },
+    });
+
+    const id1 = 1;
+    const origName1 = 'original';
+    const updatedName1 = "UPDATED";
+
+    const id2 = 2;
+    const name2 = 'other';
+
+    return User.sync({force: true}).then(function () {
+      return User.create({
+        id: id1,
+        name: origName1,
+      });
+    }).then(function(user) {
+      expect(user.name).to.equal(origName1);
+      expect(user.updatedAt).to.equalTime(user.createdAt);
+      return User.create({
+        id: id2,
+        name: name2
+      });
+    }).then(function(user) {
+      expect(user.name).to.equal(name2);
+      expect(user.updatedAt).to.equalTime(user.createdAt);
+
+      return User.upsert({
+        id: id1,
+        name: updatedName1
+      });
+    }).then(function() {
+      return User.findById(id1);
+    }).then(function(user) {
+      expect(user.name).to.equal(updatedName1);
+      expect(user.updatedAt).afterTime(user.createdAt);
+
+      return User.findById(id2);
+    }).then(function(user) {
+      // Verify that the other row is unmodified.
+      expect(user.name).to.equal(name2);
+      expect(user.updatedAt).to.equalTime(user.createdAt);
+    });
+  });
+
+  it('works with composite primary key', function () {
+    var Counter = this.sequelize.define('counter', {
+      id: {
+        type: Sequelize.INTEGER,
+        primaryKey: true
+      },
+      id2: {
+        type: Sequelize.INTEGER,
+        primaryKey: true
+      },
+      count: {
+        type: Sequelize.INTEGER
+      }
+    });
+
+    const id = 1000;
+    const id2 = 2000;
+
+    return Counter.sync({force:true}).then(function () {
+      return Counter.create({
+        id: id,
+        id2: id2,
+        count: 1,
+      }).then(function(counter) {
+        return Counter.upsert({
+          id: id,
+          id2: id2,
+          count: 2
+        });
+      }).then(function() {
+        return Counter.findOne({where: {id: id, id2: id2}});
+      }).then(function(counter) {
+        // For some reason, INTEGER columns are returned as strings, so we need
+        // to cast.
+        expect(parseInt(counter.count)).to.equal(2);
+        expect(counter.updatedAt).afterTime(counter.createdAt);
+      });
+    });
+  });
+
+  it('throws error with RETURNING', function () {
+    var User = this.sequelize.define('user', {
+      id: {
+        type: Sequelize.INTEGER,
+        primaryKey: true
+      },
+      name: {
+        type: Sequelize.STRING,
+      },
+    });
+
+    return User.sync({force: true}).then(function () {
+      return User.create({
+        id: 1,
+        name: "original",
+      });
+    }).then(function(user) {
+      var options = {returning: "*"};
+      return User.upsert({
+        id: 1,
+        name: "UPDATED"
+      }, options).catch(function(e) {
+        expect(e.message).to.contain("https://github.com/cockroachdb/cockroach/issues/6637");
+      });
+    });
+  });
+});


### PR DESCRIPTION
The Postgres dialect for Sequelize uses a stored procedure to implement
upserts, for compatibility with PostgreSQL before 9.5. CockroachDB has
upsert but no stored procedures, so this monkey patch for the built-in
Sequelize Postgres dialect replaces Sequelize's Model.upsert() with a version
that uses `INSERT ... ON CONFLICT DO UPDATE SET`, which CockroachDB does
support.

`require()`ing the package multiple times should be fine, as `index.js`
is idempotent.

Note that tests will not pass until cockroachdb/cockroach#13962 is
fixed.

Resolves cockroachdb/cockroach#12120