### PR TITLE
Bump version to 1.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sequelize-cockroachdb",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "description": "Support using Sequelize with CockroachDB.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
For reasons I'm forgetting, I published version 1.0.1 to npm but didn't
commit the version bump. So, we're using version 1.0.2 for the release
that includes @benesch's recent changes.