### PR TITLE
Make upsert work with Sequelize 4.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,5 @@
 This package makes Sequelize compatible with CockroachDB.
 
 [Learn how to build a Node.js app with CockroachDB.](https://www.cockroachlabs.com/docs/build-a-nodejs-app-with-cockroachdb-sequelize.html)
+
+Please file bugs against the [sequelize-cockroachdb project](https://github.com/cockroachdb/sequelize-cockroachdb/issues/new)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sequelize-cockroachdb",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Support using Sequelize with CockroachDB.",
   "main": "index.js",
   "scripts": {
@@ -24,6 +24,7 @@
   },
   "dependencies": {
     "pg": "^6.1.3",
+    "semver": "^5.3.0",
     "sequelize": "3.30.2 - 4"
   },
   "peerDependencies": {


### PR DESCRIPTION
Sequelize 4.x changes the signatures of various methods, including that
of QueryGenerator.upsertQuery. This changes makes sequelize-cockroachdb
compatible with Sequelize 4.x while preserving compatibility with
Sequelize 3.x.