### PR TITLE
chore: add repository and homepage info to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,10 @@
   "scripts": {
     "test": "mocha --check-leaks --colors -t 60000 --reporter spec \"tests/*_test.js\""
   },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/cockroachdb/sequelize-cockroachdb.git"
+  },
   "keywords": [
     "database",
     "sequelize",
@@ -16,6 +20,10 @@
   ],
   "author": "Cuong Do <cdo@cockroachlabs.com>",
   "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/cockroachdb/sequelize-cockroachdb/issues"
+  },
+  "homepage": "https://www.cockroachlabs.com/docs/stable/build-a-nodejs-app-with-cockroachdb-sequelize.html",
   "devDependencies": {
     "chai": "^3.5.0",
     "chai-as-promised": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "1.0.3",
   "description": "Support using Sequelize with CockroachDB.",
   "main": "index.js",
+  "directories": {
+    "test": "tests"
+  },
   "scripts": {
     "test": "mocha --check-leaks --colors -t 60000 --reporter spec \"tests/*_test.js\""
   },


### PR DESCRIPTION
## This PR

Adding this (and then publishing the latest version to npm) will let users who find this package on npm know where this repository is. As it is, I see this on [the package page](https://www.npmjs.com/package/sequelize-cockroachdb):

<img width="366" alt="screen shot 2017-08-08 at 3 20 24 pm" src="https://user-images.githubusercontent.com/1929625/29090651-39d2e604-7c4e-11e7-9419-abfc2fdc8af4.png">

No link to this GitHub repo or the cockroachlabs tutorial. This PR will fix that.

Note that I also added the `"directories"` field, which doesn't affect results of `npm pack .` (used when publishing) and isn't currently used for anything yet, but it's generated from `npm init` with npm@5.3.0 and may be useful in the future. See this: https://docs.npmjs.com/files/package.json#directories

## Other Suggestions

Outside of this PR, please do the following:

1. Publish any missing versions to npm (currently only 1.0.3)
2. Create annotated git tags for each release in this repository (at least going forward)
3. Maybe use something like [standard-version](https://github.com/conventional-changelog/standard-version) (which assumes Angular commit message conventions) to version and tag new releases (with auto-generated CHANGELOG) in the future (I am happy to submit a PR for this if you're interested)