### PR TITLE
Update sequelize dependency to get rid of security warning

### DIFF
--- a/index.js
+++ b/index.js
@@ -116,7 +116,9 @@ var upsertQueryV4 = function(tableName, insertValues, updateValues, where, model
 // Install the right version of upsertQuery for the Sequelize version we're
 // running with.
 var sequelizeVersion = require('sequelize/package.json').version;
-if (semver.satisfies(sequelizeVersion, '4.x')) {
+if (semver.satisfies(sequelizeVersion, '5.x')) {
+  QueryGenerator.upsertQuery = upsertQueryV4;
+} else if (semver.satisfies(sequelizeVersion, '4.x')) {
   QueryGenerator.upsertQuery = upsertQueryV4;
 } else if (semver.satisfies(sequelizeVersion, '3.x')) {
   QueryGenerator.upsertQuery = upsertQueryV3;

--- a/package.json
+++ b/package.json
@@ -20,15 +20,15 @@
     "chai": "^3.5.0",
     "chai-as-promised": "^6.0.0",
     "chai-datetime": "^1.4.1",
-    "mocha": "^3.2.0"
+    "mocha": "^6.1.3"
   },
   "dependencies": {
     "lodash": "^4.17.1",
     "pg": "^6.1.3",
     "semver": "^5.3.0",
-    "sequelize": "3.30.2 - 4"
+    "sequelize": "3.30.2 - 5"
   },
   "peerDependencies": {
-    "sequelize": "3.30.2 - 4"
+    "sequelize": "3.30.2 - 5"
   }
 }

--- a/tests/helper.js
+++ b/tests/helper.js
@@ -35,3 +35,7 @@ before(function() {
     typeValidation: true
   });
 });
+
+after(function() {
+  this.sequelize.close();
+})

--- a/tests/upsert_test.js
+++ b/tests/upsert_test.js
@@ -65,12 +65,12 @@ describe('upsert', function () {
         name: updatedName1
       });
     }).then(function() {
-      return User.findById(id1);
+      return User.findByPk(id1);
     }).then(function(user) {
       expect(user.name).to.equal(updatedName1);
       expect(user.updatedAt).afterTime(user.createdAt);
 
-      return User.findById(id2);
+      return User.findByPk(id2);
     }).then(function(user) {
       // Verify that the other row is unmodified.
       expect(user.name).to.equal(name2);


### PR DESCRIPTION
This is the first step towards fixing the same warning in the main
`cockroachdb/cockroach` repository.

Along the way, this fixes deprecation warnings on Model.findById,
updates an old mocha dependency that was causing warnings, and
fixes the test from hanging.