### PR TITLE
feat(types): copy over typings from sequelize

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "test": "mocha --check-leaks --colors -t 60000 --reporter spec \"tests/*_test.js\""
   },
+  "types": "types",
   "keywords": [
     "database",
     "sequelize",

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,3 @@
+declare module "sequelize-cockroachdb" {
+  export * from "sequelize";
+}


### PR DESCRIPTION
Currently typings are missing. ~so we should just copy them over to this repo and keep them in sync, every time we update the sequelize dependency.~

We can add typings to this repo by just reexporting the types from the sequelize dependency, so we do not have to update anything for future releases.