### PR TITLE
Add support for Model.findOrCreate

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,6 +18,7 @@ var semver = require('semver');
 var util = require('util');
 var _ = require('lodash');
 var Sequelize = require('sequelize');
+var PostgresDialect = require('sequelize/lib/dialects/postgres')
 var QueryGenerator = require('sequelize/lib/dialects/postgres/query-generator.js');
 var QueryTypes = require('sequelize/lib/query-types.js');
 var DataTypes = require('sequelize/lib/data-types.js');
@@ -125,6 +126,9 @@ if (semver.satisfies(sequelizeVersion, '5.x')) {
 } else {
   throw new Error("Sequelize version " + sequelizeVersion + " is unsupported");
 }
+
+// Prevents usage of CREATE/REPLACE FUNCTION when using Model.findOrCreate().
+PostgresDialect.prototype.supports.EXCEPTION = false;
 
 // The JavaScript number type cannot represent all 64-bit integers--it can only
 // exactly represent integers in the range [-2^53 + 1, 2^53 - 1]. Notably,

--- a/tests/find_or_create_test.js
+++ b/tests/find_or_create_test.js
@@ -1,0 +1,98 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+require('./helper');
+
+var expect = require('chai').expect;
+var Sequelize = require('..');
+
+function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+describe('findOrCreate', function () {
+  it('supports CockroachDB', function () {
+    expect(Sequelize.supportsCockroachDB).to.be.true;
+  });
+
+  it('creates a row when missing', function () {
+    var User = this.sequelize.define('user', {
+      id: {
+        type: Sequelize.INTEGER,
+        primaryKey: true
+      },
+      name: {
+        type: Sequelize.STRING,
+      },
+    });
+
+    const id1 = 1;
+    const origName = 'original';
+
+    return User.sync({force: true}).then(function () {
+      return User.findOrCreate({
+        where: {
+          id: id1,
+          name: origName,
+        }
+      });
+    }).then(function([user, created]) {
+      expect(user.name).to.equal(origName);
+      expect(user.updatedAt).to.equalTime(user.createdAt);
+      expect(created).to.be.true;
+      return User.findByPk(id1);
+    }).then(function(user) {
+      expect(user.name).to.equal(origName);
+      expect(user.updatedAt).to.equalTime(user.createdAt);
+    });
+  });
+
+  it('finds the row when present', function () {
+    var User = this.sequelize.define('user', {
+      id: {
+        type: Sequelize.INTEGER,
+        primaryKey: true
+      },
+      name: {
+        type: Sequelize.STRING,
+      },
+    });
+
+    const id1 = 1;
+    const origName = 'original';
+    const updatedName = "UPDATED";
+
+    return User.sync({force: true}).then(function () {
+      return User.create({
+        id: id1,
+        name: origName,
+      });
+    }).then(function(user) {
+      expect(user.name).to.equal(origName);
+      expect(user.updatedAt).to.equalTime(user.createdAt);
+      return User.findOrCreate({
+        where: {
+          id: id1,
+        },
+        defaults: {
+          name: updatedName
+        }
+      });
+    }).then(function([user, created]) {
+      expect(user.name).to.equal(origName);
+      expect(user.updatedAt).to.equalTime(user.createdAt);
+      expect(created).to.be.false;
+    });
+  });
+});


### PR DESCRIPTION
Previously, the dialect would generate a query that used the CREATE OR
REPLACE FUNCTION syntax, which is not supported in CockroachDB. This is
fixed by disabling the setting in the dialect that allows this. Tests
are added for the findOrCreate functionality.

fixes #15