### PR TITLE
Improve CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,31 +1,125 @@
+# Copyright 2020 The Cockroach Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
 name: CI
 on: [push, pull_request]
 
 jobs:
   test:
+    # Execute our own tests
+    # This one will spawn 6 jobs
+    name: Main - CRDB ${{ matrix.cockroachdb-version }}, Sequelize v${{ matrix.sequelize-version }}
     strategy:
       matrix:
         sequelize-version: [5, 6]
+        cockroachdb-version: [latest, v20.2.2, v19.2.11]
       fail-fast: false
     runs-on: ubuntu-latest
-    container: cockroachdb/cockroach:latest
-    name: Sequelize v${{ matrix.sequelize-version }}
     steps:
-      -
+      - name: Start a single CockroachDB instance (${{ matrix.cockroachdb-version }}) with docker
+        env:
+          CONTAINER_ENTRYPOINT: ${{ startsWith(matrix.cockroachdb-version, 'v19') && './cockroach' || 'cockroach' }}
+        run: |
+          echo $CONTAINER_ENTRYPOINT
+          docker pull cockroachdb/cockroach:${{ matrix.cockroachdb-version }}
+          docker run -d --name roach --hostname roach -p 26257:26257 -p 8080:8080 cockroachdb/cockroach:${{ matrix.cockroachdb-version }} start-single-node --insecure
+          sudo apt update && sudo apt install wait-for-it -y
+          wait-for-it -h localhost -p 26257
+          docker exec roach bash -c "echo 'CREATE DATABASE sequelize_test;' | $CONTAINER_ENTRYPOINT sql --insecure"
+
+      - name: Checkout the repository
         uses: actions/checkout@v2
-      -
+
+      - name: Setup Node.js 12.x
         uses: actions/setup-node@v1
         with:
           node-version: 12.x
-      -
-        run: cockroach version
-      -
-        run: cockroach start-single-node --background --insecure
-      -
-        run: echo "CREATE DATABASE sequelize_test;" | cockroach sql --insecure
-      -
+
+      - name: Install dependencies
         run: npm install
-      -
-        run: npm install --save sequelize@${{ matrix.sequelize-version }}
-      -
+
+      - name: Install Sequelize v${{ matrix.sequelize-version }}
+        run: npm install --save sequelize@^${{ matrix.sequelize-version }}
+
+      - name: Run tests
         run: npm test
+
+  sequelize-postgres-integration-tests:
+    # Execute Sequelize integration tests for postgres
+    # This one will spawn 219 jobs
+    name: (${{ matrix.sequelize-branch }}) ${{ matrix.test-path }}
+    strategy:
+      matrix:
+        sequelize-branch: [v5, v6]
+        test-path: [associations/alias, associations/belongs-to-many, associations/belongs-to, associations/has-many, associations/has-one, associations/multiple-level-filters, associations/scope, associations/self, cls, configuration, data-types, dialects/abstract/connection-manager, dialects/postgres/associations, dialects/postgres/connection-manager, dialects/postgres/dao, dialects/postgres/data-types, dialects/postgres/error, dialects/postgres/hstore, dialects/postgres/query-interface, dialects/postgres/query, dialects/postgres/range, dialects/postgres/regressions, error, hooks/associations, hooks/bulkOperation, hooks/count, hooks/create, hooks/destroy, hooks/find, hooks/hooks, hooks/restore, hooks/updateAttributes, hooks/upsert, hooks/validate, include/findAll, include/findAndCountAll, include/findOne, include/limit, include/paranoid, include/schema, include/separate, include, instance/decrement, instance/destroy, instance/increment, instance/reload, instance/save, instance/to-json, instance/update, instance/values, instance, instance.validations, json, model/attributes/field, model/attributes/types, model/attributes, model/bulk-create/include, model/bulk-create, model/count, model/create/include, model/create, model/findAll/group, model/findAll/groupedLimit, model/findAll/order, model/findAll/separate, model/findAll, model/findOne, model/findOrBuild, model/geography, model/geometry, model/increment, model/json, model/optimistic_locking, model/paranoid, model/schema, model/scope/aggregate, model/scope/associations, model/scope/count, model/scope/destroy, model/scope/find, model/scope/findAndCountAll, model/scope/merge, model/scope/update, model/scope, model/searchPath, model/sum, model/sync, model/update, model/upsert, model, operators, pool, query-interface/changeColumn, query-interface/createTable, query-interface/describeTable, query-interface/dropEnum, query-interface/removeColumn, query-interface, replication, schema, sequelize/deferrable, sequelize/log, sequelize, sequelize.transaction, timezone, transaction, trigger, utils, vectors]
+        include:
+          -
+            # Luckily the test files are the same in v5 and v6, except for one extra file in v6:
+            sequelize-branch: v6
+            test-path: sequelize/query
+      fail-fast: false
+    runs-on: ubuntu-latest
+    env:
+      DIALECT: postgres
+      SEQ_PORT: 26257
+      SEQ_USER: root
+      SEQ_PW: ''
+      SEQ_DB: sequelize_test
+    steps:
+      - name: Start a single CockroachDB instance (v20.2.2) with docker
+        run: |
+          docker pull cockroachdb/cockroach:v20.2.2
+          docker run -d --name roach --hostname roach -p 26257:26257 -p 8080:8080 cockroachdb/cockroach:v20.2.2 start-single-node --insecure
+          sudo apt update && sudo apt install wait-for-it -y
+          wait-for-it -h localhost -p 26257
+          docker exec roach bash -c 'echo "CREATE DATABASE sequelize_test;" | cockroach sql --insecure'
+
+      - name: Checkout `sequelize-cockroachdb` repository
+        uses: actions/checkout@v2
+
+      - name: Setup Node.js 12.x
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12.x
+
+      - name: Install `sequelize-cockroachdb` dependencies
+        run: npm install
+
+      - name: Fetch Sequelize source code directly from GitHub and unzip it into `.downloaded-sequelize`
+        run: |
+          wget https://github.com/sequelize/sequelize/archive/${{ matrix.sequelize-branch }}.zip
+          unzip ${{ matrix.sequelize-branch }}.zip -d temp-unzip-out
+          mv temp-unzip-out/* .downloaded-sequelize
+          rmdir temp-unzip-out
+
+      - name: Install Sequelize dependencies
+        working-directory: ./.downloaded-sequelize
+        run: npm install
+
+      - name: Provide the `sequelize-cockroachdb` patches
+        # This script needs `fs-jetpack` as an extra dependency
+        run: |
+          npm install --no-save fs-jetpack
+          node .github/workflows/helpers/put-our-patches-in-downloaded-sequelize.js
+          cat .downloaded-sequelize/.cockroachdb-patches/index.js
+
+      - name: Copy over the dependencies needed by `sequelize-cockroachdb`
+        # (we use `npm ls --prod=true` to avoid copying unnecessary dev-dependencies)
+        run: |
+          mkdir -p .downloaded-sequelize/.cockroachdb-patches/node_modules
+          npm ls --prod=true --parseable=true | grep node_modules | xargs -I{} cp -r {} .downloaded-sequelize/.cockroachdb-patches/node_modules/.
+
+      - name: Run integration tests at '${{ matrix.test-path }}' for Sequelize ${{ matrix.sequelize-branch }}
+        working-directory: ./.downloaded-sequelize
+        run: npx mocha --require ./.cockroachdb-patches/index.js --timeout 30000 --reporter spec --exit "test/integration/${{ matrix.test-path }}.test.js"

--- a/.github/workflows/helpers/put-our-patches-in-downloaded-sequelize.js
+++ b/.github/workflows/helpers/put-our-patches-in-downloaded-sequelize.js
@@ -1,0 +1,39 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+const jetpack = require('fs-jetpack');
+
+// This function wraps our source code, patching our `require` calls, to make them point to the correct relative path.
+function copyFileWrapping(sourcePath, destinationPath) {
+  const contents = jetpack.read(sourcePath);
+  jetpack.write(
+    destinationPath,
+    `
+      'use strict';
+      const originalRequire = require;
+      require = modulePath => originalRequire(modulePath.replace(/^sequelize\\b/, '..'));
+      console.log('[INFO] Applying "sequelize-cockroachdb" patches! (${JSON.stringify(destinationPath)})');
+      (() => {
+      // ------------------------------------------------------------------------------------
+      ${contents}
+      // ------------------------------------------------------------------------------------
+      })();
+    `
+  );
+}
+
+// Wrap our source code files and write the wrapped versions into `.downloaded-sequelize/.cockroachdb-patches/`
+for (const file of ['index.js', 'patch-upsert-v5.js']) {
+  copyFileWrapping(file, `.downloaded-sequelize/.cockroachdb-patches/${file}`);
+}

--- a/.github/workflows/readme.md
+++ b/.github/workflows/readme.md
@@ -1,0 +1,13 @@
+# CI workflow for executing Sequelize's postgres tests targeting CockroachDB
+
+The `ci.yml` file includes a job specification called `sequelize-postgres-integration-tests` which is responsible for running Sequelize's own integration tests that were originally written for postgres but targeting CockroachDB instead.
+
+It works as follows:
+
+* Download the Sequelize source code into a temporary folder called `.downloaded-sequelize`
+* Install all Sequelize dependencies (in order to be able to run all Sequelize's own tests)
+* Copy `sequelize-cockroachdb` source code into `.downloaded-sequelize/.cockroachdb-patches/`
+  * This is done via the `put-our-patches-in-downloaded-sequelize.js` helper file. It not only copies our source code, but also wraps it in a way that patches all our `require('sequelize')` calls to make them work inside Sequelize's source code. The `require` wrapper simply transforms arguments like `'sequelize'` into the appropriate relative path (which is `'..'` since our code is within the `.cockroach-patches` directory).
+* Tell Sequelize to execute our code (in `.downloaded-sequelize/.cockroachdb-patches/`) before running the tests
+* Run Sequelize tests
+  * Note: if a test fails in a way that the database cannot be cleaned up afterwards, this will cause the entire test execution to abort; to minimize the impact of this, the Sequelize tests will be run separately per test file instead of running all tests at once.


### PR DESCRIPTION
This PR adds a new complex GitHub Action workflow that runs all Sequelize integration tests for postgres against CockroachDB instead, using all `sequelize-cockroachdb` patches that already exist here.

This PR also improves the already existing workflow that I added in #48. It was previously running everything inside the CockroachDB container itself, but it is better to let the container exist isolated, and install NodeJS and execute everything separately (outside the container). But this part of the PR is minor, compared to the new part.

### CI output example

You can see how the execution looks like [in my fork](https://github.com/papb/sequelize-cockroachdb/runs/1496615720) or in the PR here.

### Details

Since we have a lot of tests for postgres (about 1800), and sometimes more tests are added, it wouldn't be good to just copy the tests over to this repository, because they would be easily get out of sync (and it would be a mess of a lot of files). So I have created a way to fetch the tests automatically from the Sequelize repository.

Here's how our tests work in Sequelize:
- Before beginning, we create a new empty database called sequelize_test.
- Then we run our tests serially against that database, cleaning up the whole database after each test, so that tests can be independent.
- However, if a test fails in a way that also causes the cleanup step to fail (for example, if the database gets stuck/locked in a transaction), then the testing cannot continue anymore and is aborted.

The last bullet above is undesired. Ideally we would like all other tests to still be able to run. However, this hasn't been an issue for us since the pull requests we receive are small and usually only affect a few tests. At worse, a few failures would be hidden by the first test crash, but once that fail is fixed, the other failures will reveal themselves. Therefore, this never causes a false positive - if our CI says that all tests passed, then they surely did.

However, now that I tried to run all postgres tests against CockroachDB, this problem got big: the execution didn't even reach 30 tests, while we have about 1800.

The ideal solution to this problem would be to rework the way Sequelize tests are executed, making every single test run against a fresh database. However, this would be a huge work. So I came up with a compromise that I think works well: instead of having one fresh database for each test, we will have one fresh data base for each *test file* - and there are 110 test files. This way, if a test crashes the database, it will only affect the execution of the other tests from that same file, which is much better.

So what this PR does is it configures a GitHub Action that executes one job for each Sequelize test file. It will fetch the test code directly from the Sequelize repository, so that we do not have to copy all that code to this repository (and it is also trivial to update if Sequelize itself has an update). Also, the action does this for both Sequelize v5 and v6, since your goal is to support both versions.

This will cause about 220 jobs to execute with this GitHub Action. This may look scary, but since the job limit for GitHub Actions is 256, this is absolutely fine.

I have added a `readme.md` file next to the `ci.yml`, clarifying how it works.

By the way, GitHub seems to have an intermittent bug in their UI for previewing job statuses that shows statistics adding up to only 100 jobs, even if there are more:

![PR_ATTACHMENT](https://user-images.githubusercontent.com/20914054/101116035-1a3c8200-35c3-11eb-8349-9d635aae9f67.png)

But don't worry; when you click to see the details, they are all there.

