### PR TITLE
Fix Patch for BigInt

### DIFF
--- a/tests/int_test.js
+++ b/tests/int_test.js
@@ -34,9 +34,15 @@ for (const intTypeName of ['integer', 'bigint']) {
       expect(foo.i).to.equal(42);
     });
 
-    it('accepts JavaScript strings that represent 64-bit integers', async function () {
+    // Reason: Not fully supported by Sequelize.
+    // https://github.com/sequelize/sequelize/issues/10468
+    it.skip('accepts JavaScript strings that represent 64-bit integers', async function () {
       const foo = await this.Foo.create({ i: "9223372036854775807" });
       expect(foo.i).to.equal(9223372036854775807n);
+    });
+    it('accepts JavaScript strings that represent 64-bit integers', async function () {
+      const foo = await this.Foo.create({ i: "9223372036854775807" });
+      expect(foo.i).to.equal("9223372036854775807");
     });
 
     it('rejects integers that overflow', async function () {


### PR DESCRIPTION
After researching the origin of the patches, I've commented better when each one appeared. This alters the parsing of BigInts into Strings. By that, it has to skip DataTypes.BIGINT tests.