### PR TITLE
Fix bulk create

### DIFF
--- a/.github/workflows/test_names.txt
+++ b/.github/workflows/test_names.txt
@@ -23,3 +23,6 @@ should work with enums (case 1)
 should work with enums (case 2)
 should work with enums with schemas
 should be able to remove a column with primaryKey
+should make the auto incremented values available on the returned instances
+should make the auto incremented values available on the returned instances with custom fields
+should return auto increment primary key values

--- a/tests/model_bulk_create_test.js
+++ b/tests/model_bulk_create_test.js
@@ -1,0 +1,180 @@
+require('./helper');
+
+const { expect } = require('chai');
+const { Sequelize, DataTypes } = require('../source');
+
+describe('Model', () => {
+  beforeEach(async function() {
+    this.User = this.sequelize.define('User', {
+      username: DataTypes.STRING,
+      secretValue: {
+        type: DataTypes.STRING,
+        field: 'secret_value'
+      },
+      data: DataTypes.STRING,
+      intVal: DataTypes.INTEGER,
+      theDate: DataTypes.DATE,
+      aBool: DataTypes.BOOLEAN,
+      uniqueName: { type: DataTypes.STRING, unique: true }
+    });
+    this.Account = this.sequelize.define('Account', {
+      accountName: DataTypes.STRING
+    });
+    this.Student = this.sequelize.define('Student', {
+      no: { type: DataTypes.INTEGER, primaryKey: true },
+      name: { type: DataTypes.STRING, allowNull: false }
+    });
+    this.Car = this.sequelize.define('Car', {
+      plateNumber: {
+        type: DataTypes.STRING,
+        primaryKey: true,
+        field: 'plate_number'
+      },
+      color: {
+        type: DataTypes.TEXT
+      }
+    });
+
+    await this.sequelize.sync({ force: true });
+  });
+
+  describe('bulkCreate', () => {
+    it.skip('supports transactions', async function() {
+      const User = this.sequelize.define('User', {
+        username: DataTypes.STRING
+      });
+      await User.sync({ force: true });
+      const transaction = await this.sequelize.transaction();
+      await User.bulkCreate([{ username: 'foo' }, { username: 'bar' }], { transaction });
+      const count1 = await User.count();
+      const count2 = await User.count({ transaction });
+      expect(count1).to.equal(0);
+      expect(count2).to.equal(2);
+      await transaction.rollback();
+    });
+
+    // Reason: CRDB does not grant autoIncrement to be sequential and usually does not gives it
+    // small numbers like PG does. Reimplementing the test to check if it is incremental below.
+    describe('return values', () => {
+      it.skip('should make the auto incremented values available on the returned instances', async function() {
+        const User = this.sequelize.define('user', {});
+
+        await User
+          .sync({ force: true });
+
+        const users0 = await User.bulkCreate([
+          {},
+          {},
+          {}
+        ], {
+          returning: true
+        });
+
+        const actualUsers0 = await User.findAll({ order: ['id'] });
+        const [users, actualUsers] = [users0, actualUsers0];
+        expect(users.length).to.eql(actualUsers.length);
+        users.forEach((user, i) => {
+          expect(user.get('id')).to.be.ok;
+          expect(user.get('id')).to.equal(actualUsers[i].get('id'))
+            .and.to.equal(i + 1);
+        });
+      });
+      it('should make the auto incremented values available on the returned instances', async function() {
+        const User = this.sequelize.define('user', {});
+
+        await User.sync({ force: true });
+
+        const users = await User.bulkCreate([{}, {}, {}], {
+          returning: true
+        });
+
+        const actualUsers = await User.findAll({ order: ['id'] });
+
+        const usersIds = users.map(user => user.get('id'));
+        const actualUserIds = actualUsers.map(user => user.get('id'));
+        const orderedUserIds = usersIds.sort((a, b) => a - b);
+
+        users.forEach(user => expect(user.get('id')).to.be.ok);
+        expect(usersIds).to.eql(actualUserIds);
+        expect(usersIds).to.eql(orderedUserIds);
+      });
+
+      // Reason: CRDB does not grant autoIncrement to be sequential and usually does not gives it
+      // small numbers like PG does. Reimplementing the test to check if it is incremental below.
+      it.skip('should make the auto incremented values available on the returned instances with custom fields', async function() {
+        const User = this.sequelize.define('user', {
+          maId: {
+            type: DataTypes.INTEGER,
+            primaryKey: true,
+            autoIncrement: true,
+            field: 'yo_id'
+          }
+        });
+        
+        await User.sync({ force: true });
+        
+        const users = await User.bulkCreate([{}, {}, {}], { returning: true });
+        
+        const actualUsers = await User.findAll({ order: ['maId'] });
+        
+        expect(users.length).to.eql(actualUsers.length);
+        users.forEach((user, i) => {
+          expect(user.get('maId')).to.be.ok;
+          expect(user.get('maId')).to.equal(actualUsers[i].get('maId'))
+          .and.to.equal(i + 1);
+        });
+      });
+      it('should make the auto incremented values available on the returned instances with custom fields', async function() {
+        const User = this.sequelize.define('user', {
+          maId: {
+            type: DataTypes.INTEGER,
+            primaryKey: true,
+            autoIncrement: true,
+            field: 'yo_id'
+          }
+        });
+
+        await User.sync({ force: true });
+
+        const users = await User.bulkCreate([{}, {}, {}], { returning: true });
+
+        const actualUsers = await User.findAll({ order: ['maId'] });
+
+        const usersIds = users.map(user => user.get('maId'));
+        const actualUserIds = actualUsers.map(user => user.get('maId'));
+        const orderedUserIds = usersIds.sort((a, b) => a - b);
+
+        users.forEach(user => expect(user.get('maId')).to.be.ok);
+        expect(usersIds).to.eql(actualUserIds);
+        expect(usersIds).to.eql(orderedUserIds);
+      });
+    });
+
+    describe('handles auto increment values', () => {
+      // Reason: CRDB does not grant autoIncrement to be sequential and usually does not gives it
+      // small numbers like PG does. Reimplementing the test to check if it is incremental below.
+      it.skip('should return auto increment primary key values', async function() {
+        const Maya = this.sequelize.define('Maya', {});
+
+        const M1 = {};
+        const M2 = {};
+
+        await Maya.sync({ force: true });
+        const ms = await Maya.bulkCreate([M1, M2], { returning: true });
+        expect(ms[0].id).to.be.eql(1);
+        expect(ms[1].id).to.be.eql(2);
+      });
+      it('should return auto increment primary key values', async function() {
+        const Maya = this.sequelize.define('Maya', {});
+
+        const M1 = {};
+        const M2 = {};
+
+        await Maya.sync({ force: true });
+        const ms = await Maya.bulkCreate([M1, M2], { returning: true });
+        
+        expect(ms[0].id < ms[1].id).to.be.true;
+      });
+    });
+  });
+});

--- a/tests/model_bulk_create_test.js
+++ b/tests/model_bulk_create_test.js
@@ -1,7 +1,7 @@
 require('./helper');
 
 const { expect } = require('chai');
-const { Sequelize, DataTypes } = require('../source');
+const { DataTypes } = require('../source');
 
 describe('Model', () => {
   beforeEach(async function() {
@@ -53,22 +53,15 @@ describe('Model', () => {
       await transaction.rollback();
     });
 
-    // Reason: CRDB does not grant autoIncrement to be sequential and usually does not gives it
-    // small numbers like PG does. Reimplementing the test to check if it is incremental below.
+    // Reason: CRDB does not guarantee autoIncrement to be sequential.
+    // Reimplementing the test to check if it is incremental below.
     describe('return values', () => {
       it.skip('should make the auto incremented values available on the returned instances', async function() {
         const User = this.sequelize.define('user', {});
 
-        await User
-          .sync({ force: true });
+        await User.sync({ force: true });
 
-        const users0 = await User.bulkCreate([
-          {},
-          {},
-          {}
-        ], {
-          returning: true
-        });
+        const users0 = await User.bulkCreate([{}, {}, {}], { returning: true });
 
         const actualUsers0 = await User.findAll({ order: ['id'] });
         const [users, actualUsers] = [users0, actualUsers0];
@@ -84,9 +77,7 @@ describe('Model', () => {
 
         await User.sync({ force: true });
 
-        const users = await User.bulkCreate([{}, {}, {}], {
-          returning: true
-        });
+        const users = await User.bulkCreate([{}, {}, {}], { returning: true });
 
         const actualUsers = await User.findAll({ order: ['id'] });
 
@@ -99,8 +90,8 @@ describe('Model', () => {
         expect(usersIds).to.eql(orderedUserIds);
       });
 
-      // Reason: CRDB does not grant autoIncrement to be sequential and usually does not gives it
-      // small numbers like PG does. Reimplementing the test to check if it is incremental below.
+      // Reason: CRDB does not guarantee autoIncrement to be sequential.
+      // Reimplementing the test to check if it is incremental below.
       it.skip('should make the auto incremented values available on the returned instances with custom fields', async function() {
         const User = this.sequelize.define('user', {
           maId: {
@@ -151,8 +142,8 @@ describe('Model', () => {
     });
 
     describe('handles auto increment values', () => {
-      // Reason: CRDB does not grant autoIncrement to be sequential and usually does not gives it
-      // small numbers like PG does. Reimplementing the test to check if it is incremental below.
+      // Reason: CRDB does not guarantee autoIncrement to be sequential.
+      // Reimplementing the test to check if it is incremental below.
       it.skip('should return auto increment primary key values', async function() {
         const Maya = this.sequelize.define('Maya', {});
 


### PR DESCRIPTION
The skipped tests were about expecting human-readable and also sequential ids.