### PR TITLE
Add v5 to ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         # TODO(richardjcai): Re-enable tests for v5 after we get v6 suite passing.
         # Focus on getting tests passing for v6 test suite.
-        sequelize-version: [6]
+        sequelize-version: [5, 6]
         cockroachdb-docker-version: ["cockroachdb/cockroach:v20.2.4", "cockroachdb/cockroach-unstable:v21.1.0-beta.2"]
       fail-fast: false
     runs-on: ubuntu-latest
@@ -65,7 +65,7 @@ jobs:
       matrix:
         # TODO(richardjcai): Re-enable tests for v5 after we get v6 suite passing.
         # Focus on getting tests passing for v6 test suite.
-        sequelize-branch: [v6]
+        sequelize-branch: [v5, v6]
         test-path: [associations/alias, associations/belongs-to-many, associations/belongs-to, associations/has-many, associations/has-one, associations/multiple-level-filters, associations/scope, associations/self, cls, configuration, data-types, dialects/abstract/connection-manager, dialects/postgres/associations, dialects/postgres/connection-manager, dialects/postgres/dao, dialects/postgres/data-types, dialects/postgres/error, dialects/postgres/hstore, dialects/postgres/query-interface, dialects/postgres/query, dialects/postgres/range, dialects/postgres/regressions, error, hooks/associations, hooks/bulkOperation, hooks/count, hooks/create, hooks/destroy, hooks/find, hooks/hooks, hooks/restore, hooks/updateAttributes, hooks/upsert, hooks/validate, include/findAll, include/findAndCountAll, include/findOne, include/limit, include/paranoid, include/schema, include/separate, include, instance/decrement, instance/destroy, instance/increment, instance/reload, instance/save, instance/to-json, instance/update, instance/values, instance, instance.validations, json, model/attributes/field, model/attributes/types, model/attributes, model/bulk-create/include, model/bulk-create, model/count, model/create/include, model/create, model/findAll/group, model/findAll/groupedLimit, model/findAll/order, model/findAll/separate, model/findAll, model/findOne, model/findOrBuild, model/geography, model/geometry, model/increment, model/json, model/optimistic_locking, model/paranoid, model/schema, model/scope/aggregate, model/scope/associations, model/scope/count, model/scope/destroy, model/scope/find, model/scope/findAndCountAll, model/scope/merge, model/scope/update, model/scope, model/searchPath, model/sum, model/sync, model/update, model/upsert, model, operators, pool, query-interface/changeColumn, query-interface/createTable, query-interface/describeTable, query-interface/dropEnum, query-interface/removeColumn, query-interface, replication, schema, sequelize/deferrable, sequelize/log, sequelize, sequelize.transaction, timezone, transaction, trigger, utils, vectors]
         include:
           -

--- a/source/patch-upsert-v5.js
+++ b/source/patch-upsert-v5.js
@@ -16,7 +16,7 @@
 
 const { Model, DataTypes, QueryTypes } = require('sequelize');
 const _ = require('lodash');
-const uuidv4 = require('uuid/v4');
+const uuidv4 = require('uuid').v4;
 const Promise = require('sequelize/lib/promise');
 const Utils = require('sequelize/lib/utils');
 const { logger } = require('sequelize/lib/utils/logger');


### PR DESCRIPTION
To check which tests still fail with Sequelize V5, re-added V5.