### PR TITLE
Fix operators test

### DIFF
--- a/.github/workflows/ignore_tests/operators.txt
+++ b/.github/workflows/ignore_tests/operators.txt
@@ -1,0 +1,2 @@
+should properly escape regular expressions
+should work with a case-insensitive not regexp where

--- a/tests/operators_test.js
+++ b/tests/operators_test.js
@@ -1,0 +1,120 @@
+'use strict';
+
+require('./helper');
+
+const { expect } = require('chai'),
+  { DataTypes, Sequelize } = require('../source'),
+  Op = Sequelize.Op;
+
+describe('Operators', () => {
+  describe('REGEXP', () => {
+    beforeEach(async function () {
+      this.User = this.sequelize.define(
+        'user',
+        {
+          id: {
+            type: DataTypes.INTEGER,
+            allowNull: false,
+            primaryKey: true,
+            autoIncrement: true,
+            field: 'userId'
+          },
+          name: {
+            type: DataTypes.STRING,
+            field: 'full_name'
+          }
+        },
+        {
+          tableName: 'users',
+          timestamps: false
+        }
+      );
+
+      await this.sequelize.getQueryInterface().createTable('users', {
+        userId: {
+          type: DataTypes.INTEGER,
+          allowNull: false,
+          primaryKey: true,
+          autoIncrement: true
+        },
+        full_name: {
+          type: DataTypes.STRING
+        }
+      });
+    });
+
+    describe('case sensitive', () => {
+      it('should work with a regexp where', async function () {
+        await this.User.create({ name: 'Foobar' });
+        const user = await this.User.findOne({
+          where: {
+            name: { [Op.regexp]: '^Foo' }
+          }
+        });
+        expect(user).to.be.ok;
+      });
+
+      it('should work with a not regexp where', async function () {
+        await this.User.create({ name: 'Foobar' });
+        const user = await this.User.findOne({
+          where: {
+            name: { [Op.notRegexp]: '^Foo' }
+          }
+        });
+        expect(user).to.not.be.ok;
+      });
+
+      it('should properly escape regular expressions', async function () {
+        await this.User.bulkCreate([{ name: 'John' }, { name: 'Bob' }]);
+        await this.User.findAll({
+          where: {
+            name: { [Op.notRegexp]: "Bob'; drop table users --" }
+          }
+        });
+        await this.User.findAll({
+          where: {
+            name: { [Op.regexp]: "Bob'; drop table users --" }
+          }
+        });
+        expect(await this.User.findAll()).to.have.length(2);
+      });
+    });
+
+    describe('case insensitive', () => {
+      it('should work with a case-insensitive regexp where', async function () {
+        await this.User.create({ name: 'Foobar' });
+        const user = await this.User.findOne({
+          where: {
+            name: { [Op.iRegexp]: '^foo' }
+          }
+        });
+        expect(user).to.be.ok;
+      });
+
+      it('should work with a case-insensitive not regexp where', async function () {
+        await this.User.create({ name: 'Foobar' });
+        const user = await this.User.findOne({
+          where: {
+            name: { [Op.notIRegexp]: '^foo' }
+          }
+        });
+        expect(user).to.not.be.ok;
+      });
+
+      it('should properly escape regular expressions', async function () {
+        await this.User.bulkCreate([{ name: 'John' }, { name: 'Bob' }]);
+        await this.User.findAll({
+          where: {
+            name: { [Op.iRegexp]: "Bob'; drop table users --" }
+          }
+        });
+        await this.User.findAll({
+          where: {
+            name: { [Op.notIRegexp]: "Bob'; drop table users --" }
+          }
+        });
+        expect(await this.User.findAll()).to.have.length(2);
+      });
+    });
+  });
+});


### PR DESCRIPTION
Operators tests passes locally in this repository but fails when running against Sequelize repository. The reason is that the DB is not being cleaned before each test there. The fix here is to ignore them on Sequelize suite and letting them run unchanged in this repository.

Reference CI run:
https://github.com/cockroachdb/sequelize-cockroachdb/runs/2641411337?check_suite_focus=true#step:10:390