### PR TITLE
WIP: Add CRDB v21 to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,6 @@ jobs:
     name: Main - CRDB ${{ matrix.cockroachdb-docker-version }}, Sequelize v${{ matrix.sequelize-version }}
     strategy:
       matrix:
-        # TODO(richardjcai): Re-enable tests for v5 after we get v6 suite passing.
-        # Focus on getting tests passing for v6 test suite.
         sequelize-version: [5, 6]
         cockroachdb-docker-version: ["cockroachdb/cockroach:v20.2.4", "cockroachdb/cockroach-unstable:v21.1.0-beta.2"]
       fail-fast: false
@@ -63,8 +61,6 @@ jobs:
     name: (${{ matrix.sequelize-branch }}) ${{ matrix.test-path }}
     strategy:
       matrix:
-        # TODO(richardjcai): Re-enable tests for v5 after we get v6 suite passing.
-        # Focus on getting tests passing for v6 test suite.
         sequelize-branch: [v5, v6]
         test-path: [associations/alias, associations/belongs-to-many, associations/belongs-to, associations/has-many, associations/has-one, associations/multiple-level-filters, associations/scope, associations/self, cls, configuration, data-types, dialects/abstract/connection-manager, dialects/postgres/associations, dialects/postgres/connection-manager, dialects/postgres/dao, dialects/postgres/data-types, dialects/postgres/error, dialects/postgres/hstore, dialects/postgres/query-interface, dialects/postgres/query, dialects/postgres/range, dialects/postgres/regressions, error, hooks/associations, hooks/bulkOperation, hooks/count, hooks/create, hooks/destroy, hooks/find, hooks/hooks, hooks/restore, hooks/updateAttributes, hooks/upsert, hooks/validate, include/findAll, include/findAndCountAll, include/findOne, include/limit, include/paranoid, include/schema, include/separate, include, instance/decrement, instance/destroy, instance/increment, instance/reload, instance/save, instance/to-json, instance/update, instance/values, instance, instance.validations, json, model/attributes/field, model/attributes/types, model/attributes, model/bulk-create/include, model/bulk-create, model/count, model/create/include, model/create, model/findAll/group, model/findAll/groupedLimit, model/findAll/order, model/findAll/separate, model/findAll, model/findOne, model/findOrBuild, model/geography, model/geometry, model/increment, model/json, model/optimistic_locking, model/paranoid, model/schema, model/scope/aggregate, model/scope/associations, model/scope/count, model/scope/destroy, model/scope/find, model/scope/findAndCountAll, model/scope/merge, model/scope/update, model/scope, model/searchPath, model/sum, model/sync, model/update, model/upsert, model, operators, pool, query-interface/changeColumn, query-interface/createTable, query-interface/describeTable, query-interface/dropEnum, query-interface/removeColumn, query-interface, replication, schema, sequelize/deferrable, sequelize/log, sequelize, sequelize.transaction, timezone, transaction, trigger, utils, vectors]
         include:
@@ -81,10 +77,10 @@ jobs:
       SEQ_PW: ''
       SEQ_DB: sequelize_test
     steps:
-      - name: Start a single CockroachDB instance (v20.2.4) with docker
+      - name: Start a single CockroachDB instance with docker
         run: |
-          docker pull cockroachdb/cockroach:v20.2.4
-          docker run -d --name roach --hostname roach -p 26257:26257 -p 8080:8080 cockroachdb/cockroach:v20.2.4 start-single-node --insecure
+          docker pull cockroachdb/cockroach:v21.1.0
+          docker run -d --name roach --hostname roach -p 26257:26257 -p 8080:8080 cockroachdb/cockroach:v21.1.0 start-single-node --insecure
           sudo apt update && sudo apt install wait-for-it -y
           wait-for-it -h localhost -p 26257
           docker exec roach bash -c 'echo "CREATE DATABASE sequelize_test;" | cockroach sql --insecure'


### PR DESCRIPTION
Added CRDB v21 to run against both Sequelize v5 and v6. Removed CRDB v20 because GH Actions can hold only 256 jobs and this would spawn more than it. Gotta rethink the CI flow or let it be just v21.