### PR TITLE
Add telemetry to Sequelize.

### DIFF
--- a/source/index.js
+++ b/source/index.js
@@ -27,16 +27,10 @@ const { Sequelize, DataTypes, Model } = require('sequelize');
 const QueryGenerator = require('sequelize/lib/dialects/postgres/query-generator');
 
 // Ensure Sequelize version compatibility.
+var version_helper = require ('./version_helper.js')
 const semver = require('semver');
-const { version, release } = require('sequelize/package.json');
-// In v4 and v5 package.json files, have a property 'release: { branch: 'v5' }'
-// but in v6 it has 'release: { branches: ['v6'] }'
-const branchVersion = release.branches ? release.branches[0] : release.branch;
-// When executing the tests on Github Actions the version it gets from sequelize is from the repository which has a development version '0.0.0-development'
-// in that case we fallback to a branch version
-const sequelizeVersion = semver.coerce(
-  version === '0.0.0-development' ? branchVersion : version
-);
+
+const sequelizeVersion = version_helper.GetSequelizeVersion()
 
 if (semver.satisfies(sequelizeVersion, '<=4')) {
   throw new Error(
@@ -44,8 +38,9 @@ if (semver.satisfies(sequelizeVersion, '<=4')) {
   );
 }
 
-//// [1] Override the `upsert` query method from Sequelize v5 to make it work with CockroachDB
+require('./telemetry.js')
 
+//// [1] Override the `upsert` query method from Sequelize v5 to make it work with CockroachDB
 if (semver.satisfies(sequelizeVersion, '5.x')) {
   require('./patch-upsert-v5');
   require('./patches-v5');

--- a/source/telemetry.js
+++ b/source/telemetry.js
@@ -22,10 +22,8 @@ Sequelize.addHook('afterInit', async (connection) => {
             return
         }
         var sequelizeVersion = version_helper.GetSequelizeVersion()
-        console.log(sequelizeVersion.version)
         await connection.query(`SELECT crdb_internal.increment_feature_counter('Sequelize ${sequelizeVersion.version}')`, { type: QueryTypes.SELECT });
     } catch (error) {
-        console.warn("Could not record telemetry.")
-        console.warn(error)
+        console.info("Could not record telemetry.\n" + error)
     }
 });

--- a/source/telemetry.js
+++ b/source/telemetry.js
@@ -1,0 +1,31 @@
+const { Sequelize, QueryTypes } = require('sequelize');
+
+const version_helper = require('./version_helper.js')
+
+//// Log telemetry for Sequelize ORM.
+Sequelize.addHook('afterInit', async (connection) => {
+    try {
+        var telemetryDisabled = connection.options.dialectOptions.cockroachdbTelemetryDisabled
+        if (telemetryDisabled) {
+            return 
+        }
+        const versionRow = await connection.query("SELECT version() AS version", { type: QueryTypes.SELECT });
+        version = versionRow[0]["version"]
+
+        // This regex pattern should match any version 21.1 and greater.
+        // Also assumes that the naming scheme will always follow v[XX].[Y].[ZZZZ]
+        // Where XX is the last two digits of the year, Y is the subrelease (currently is always 1/2) and
+        // ZZZZ is the point release version.
+        // This has to be updated if the version format changes or a new version of CockroachDB is released in the year 2100.
+        var re = new RegExp('v([2-9][1-9]|[3-9][0-9]).[1-2].[0-9]*')
+        if (!version.match(re)) {
+            return
+        }
+        var sequelizeVersion = version_helper.GetSequelizeVersion()
+        console.log(sequelizeVersion.version)
+        await connection.query(`SELECT crdb_internal.increment_feature_counter('Sequelize ${sequelizeVersion.version}')`, { type: QueryTypes.SELECT });
+    } catch (error) {
+        console.warn("Could not record telemetry.")
+        console.warn(error)
+    }
+});

--- a/source/version_helper.js
+++ b/source/version_helper.js
@@ -1,0 +1,14 @@
+const semver = require('semver');
+const { version, release } = require('sequelize/package.json');
+
+module.exports = {
+  GetSequelizeVersion: function() {
+      // In v4 and v5 package.json files, have a property 'release: { branch: 'v5' }'
+      // but in v6 it has 'release: { branches: ['v6'] }'
+      var branchVersion = release.branches ? release.branches[0] : release.branch;
+      // When executing the tests on Github Actions the version it gets from sequelize is from the repository which has a development version '0.0.0-development'
+      // in that case we fallback to a branch version
+      return semver.coerce(version === '0.0.0-development' ? branchVersion : version);
+  },
+};
+

--- a/tests/belongs_to_many_test.js
+++ b/tests/belongs_to_many_test.js
@@ -36,7 +36,8 @@ var Support = {
       typeValidation: true,
       define: {
         paranoid: true
-      }
+      },
+      dialectOptions: {cockroachdbTelemetryDisabled : true},
     });
   }
 };

--- a/tests/helper.js
+++ b/tests/helper.js
@@ -51,7 +51,8 @@ before(function () {
     dialect: 'postgres',
     port: process.env.COCKROACH_PORT || 26257,
     logging: false,
-    typeValidation: true
+    typeValidation: true,
+    dialectOptions: {cockroachdbTelemetryDisabled : true},
   });
 });
 


### PR DESCRIPTION
Telemetry is enabled by default unless users explicitly set
dialectOptions: {cockroachdbTelemetryDisabled : true} in
the sequelize constructor's options field.

Gotta remember to make a docs update for the telemetry config as well.