### PR TITLE
Sanitize version string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,2 @@
+# Version 6.0.0
+Released June 14, 2021

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sequelize-cockroachdb",
-  "version": "6.0.0-beta.0",
+  "version": "6.0.0",
   "description": "Support using Sequelize with CockroachDB.",
   "license": "Apache-2.0",
   "repository": "cockroachdb/sequelize-cockroachdb",

--- a/source/telemetry.js
+++ b/source/telemetry.js
@@ -17,7 +17,8 @@ Sequelize.addHook('afterInit', async (connection) => {
             return
         }
         var sequelizeVersion = version_helper.GetSequelizeVersion()
-        await connection.query(`SELECT crdb_internal.increment_feature_counter('Sequelize ${sequelizeVersion.version}')`, { type: QueryTypes.SELECT });
+        await connection.query(`SELECT crdb_internal.increment_feature_counter(concat('Sequelize ', :SequelizeVersion))`,  
+        { replacements: { SequelizeVersion: sequelizeVersion.version  }, type: QueryTypes.SELECT })
     } catch (error) {
         console.info("Could not record telemetry.\n" + error)
     }


### PR DESCRIPTION
Using replacements in the sequelize.query function is safe
since the string is escaped.

https://github.com/cockroachdb/cockroach/issues/66500
Fixes Sequelize part here.