### PR TITLE
Add telemetry for adapter version

### DIFF
--- a/source/telemetry.js
+++ b/source/telemetry.js
@@ -19,6 +19,10 @@ Sequelize.addHook('afterInit', async (connection) => {
         var sequelizeVersion = version_helper.GetSequelizeVersion()
         await connection.query(`SELECT crdb_internal.increment_feature_counter(concat('Sequelize ', :SequelizeVersion))`,  
         { replacements: { SequelizeVersion: sequelizeVersion.version  }, type: QueryTypes.SELECT })
+
+        var adapterVersion = version_helper.GetAdapterVersion()
+        await connection.query(`SELECT crdb_internal.increment_feature_counter(concat('sequelize-cockroachdb ', :AdapterVersion))`,  
+        { replacements: { AdapterVersion: adapterVersion.version }, type: QueryTypes.SELECT })
     } catch (error) {
         console.info("Could not record telemetry.\n" + error)
     }

--- a/source/version_helper.js
+++ b/source/version_helper.js
@@ -11,6 +11,10 @@ module.exports = {
       // in that case we fallback to a branch version
       return semver.coerce(version === '0.0.0-development' ? branchVersion : version);
   },
+  GetAdapterVersion: function() {
+    const pkgVersion = require('../package.json').version;
+    return semver.coerce(pkgVersion);
+  },
   IsCockroachVersion21_1Plus: async function(connection) {
     const versionRow = await connection.query("SELECT version() AS version", { type: QueryTypes.SELECT });
     const cockroachDBVersion = versionRow[0]["version"]


### PR DESCRIPTION
Call crdb_internal.increment_feature_counter with the sequelize-cockroachdb adapter version.

The adapter's telemetry has the format "sequelize-cockroachdb 6.0.0"