### PR TITLE
Add missing util import

### DIFF
--- a/source/index.js
+++ b/source/index.js
@@ -23,6 +23,7 @@ try {
   );
 }
 
+const util = require('util');
 const { Sequelize, DataTypes, Model } = require('sequelize');
 const QueryGenerator = require('sequelize/lib/dialects/postgres/query-generator');
 


### PR DESCRIPTION
fixes https://github.com/cockroachdb/sequelize-cockroachdb/issues/130

The import was incorrectly removed in c38575783d49a41967b2067260b8ee06f2a67249

But the util package is still used.