### PR TITLE
Track Sequelize version series instead of exact version

### DIFF
--- a/source/telemetry.js
+++ b/source/telemetry.js
@@ -17,8 +17,10 @@ Sequelize.addHook('afterInit', async (connection) => {
             return
         }
         var sequelizeVersion = version_helper.GetSequelizeVersion()
-        await connection.query(`SELECT crdb_internal.increment_feature_counter(concat('Sequelize ', :SequelizeVersion))`,  
-        { replacements: { SequelizeVersion: sequelizeVersion.version  }, type: QueryTypes.SELECT })
+        var sequelizeVersionSeries = version_helper.GetVersionSeries(sequelizeVersion.version)
+        var sequelizeVersionStr = (sequelizeVersionSeries===null)?sequelizeVersion:sequelizeVersionSeries
+        await connection.query(`SELECT crdb_internal.increment_feature_counter(concat('Sequelize ', :SequelizeVersionString))`,  
+        { replacements: { SequelizeVersionString: sequelizeVersionStr }, type: QueryTypes.SELECT })
 
         var adapterVersion = version_helper.GetAdapterVersion()
         await connection.query(`SELECT crdb_internal.increment_feature_counter(concat('sequelize-cockroachdb ', :AdapterVersion))`,  

--- a/source/version_helper.js
+++ b/source/version_helper.js
@@ -24,6 +24,16 @@ module.exports = {
   GetCockroachDBVersionFromEnvConfig: function() {
     const crdbVersion = process.env['CRDB_VERSION'] 
     return semver.coerce(crdbVersion)
+  },
+  GetVersionSeries: function(versionStr) {
+    // Get the version series from a version string.
+    // E.g. "6.0.1" is of series "6.0".
+    const regExp=/(\d+\.\d+)(\.|$)/mg
+    let match = regExp.exec(versionStr);
+    if (match === null || match.length < 3) {
+      return null
+    }
+    return match[1]
   }
 };
 


### PR DESCRIPTION
Track the version with the minor release truncated.
E.g. both 6.0.9 and SQLAlchemy 6.0.8
will be registered as the hash of 6.0.